### PR TITLE
Resolve NPE on import of calibrated product data

### DIFF
--- a/src/main/java/com/airbus/snap/dataio/novasar/NovaSARProductDirectory.java
+++ b/src/main/java/com/airbus/snap/dataio/novasar/NovaSARProductDirectory.java
@@ -370,7 +370,7 @@ protected void addAbstractedMetadataHeader(final MetadataElement root) throws IO
     if (calStatus.equalsIgnoreCase("CALIBRATED"))
     {
         AbstractMetadata.setAttribute(absRoot, AbstractMetadata.abs_calibration_flag, 1);
-        double calConstant = imageAttributes.getElement("CalibrationConstant").getAttributeDouble("CalibrationConstant", 1.0);
+        double calConstant = imageAttributes.getAttributeDouble("CalibrationConstant", 1.0);
         AbstractMetadata.setAttribute(absRoot, AbstractMetadata.calibration_factor, calConstant);
     }
     else


### PR DESCRIPTION
Resolves #1 

@marpet will this also be built against 6.0.x for the SNAP 6.0 and pushed to the updatecenters?

I've tested this fix locally also.
