### PR TITLE
Fix product reading for all current products

### DIFF
--- a/src/main/java/com/airbus/snap/dataio/novasar/NovaSARProductDirectory.java
+++ b/src/main/java/com/airbus/snap/dataio/novasar/NovaSARProductDirectory.java
@@ -434,7 +434,15 @@ protected void addAbstractedMetadataHeader(final MetadataElement root) throws IO
     AbstractMetadata.setAttribute(absRoot, AbstractMetadata.last_line_time, stopTime);
 
     // Extract Number of Range Looks
-    int numRangeLooks = Integer.parseInt(imageGenerationParameters.getAttributeString("NumberOfRangeLooks", defStr));
+    // Special Case for Product 29 which has different looks for its output images.
+    final MetadataElement numRangeLooksElement = imageGenerationParameters.getElement("NumberOfRangeLooks");
+    int numRangeLooks;
+    if (numRangeLooksElement != null && numRangeLooksElement.getNumAttributes() >= 2) {
+        numRangeLooks = Integer.parseInt(numRangeLooksElement.getAttributeString("NumberOfRangeLooks", defStr));
+    } else {
+        numRangeLooks = Integer.parseInt(imageGenerationParameters.getAttributeString("NumberOfRangeLooks", defStr));
+    }
+
     AbstractMetadata.setAttribute(absRoot, AbstractMetadata.range_looks, numRangeLooks);
 
     // Extract Number of Azimuth Looks


### PR DESCRIPTION
Add special case for Product with differing range looks causing the metadata parser to fail to read the information from the metadata due to multiple attributes. Verify element is not null as some products parse correctly with previous method, but getElement on NumberOfRangeLooks returns null.

Note that until ProductTable.java in snap-engine is updated, cannot create a product library with these products as the number of characters in the product type exceeds 30.